### PR TITLE
reset memory stream position when key is loaded from the stream explicitly

### DIFF
--- a/SecureStore/SecretsManager.cs
+++ b/SecureStore/SecretsManager.cs
@@ -153,6 +153,8 @@ namespace NeoSmart.SecureStore
                 }
             }
 
+            mstream.Seek(0, SeekOrigin.Begin);
+
             if (mstream.Length == KEYLENGTH * KEYCOUNT)
             {
                 LoadLegacyKeyFromStream(mstream);
@@ -257,6 +259,8 @@ namespace NeoSmart.SecureStore
                     throw new InvalidKeyFileException("Key from stream is too large!");
                 }
             }
+
+            mstream.Seek(0, SeekOrigin.Begin);
 
             if (mstream.Length == KEYLENGTH * KEYCOUNT)
             {

--- a/Tests/FunctionalityTests.cs
+++ b/Tests/FunctionalityTests.cs
@@ -2,6 +2,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NeoSmart.SecureStore;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading.Tasks;
 
 namespace Tests
 {
@@ -96,6 +97,48 @@ namespace Tests
                     {
                         Assert.AreEqual(SecureData[key], sman.Get(key), $"Retrieved data for key \"{key}\" does not match stored value!");
                     }
+                }
+            }
+        }
+
+        [TestMethod]
+        public void StoreAndLoadKeyFromStream()
+        {
+            var storePath = Path.GetTempFileName();
+            var keyPath = Path.GetTempFileName();
+
+            CreateTestStore(storePath, keyPath);
+
+            using (var storeStream = new FileStream(storePath, FileMode.Open, FileAccess.Read))
+            using (var keyStream = new FileStream(keyPath, FileMode.Open, FileAccess.Read))
+            using (var sman = SecretsManager.LoadStore(storeStream))
+            {
+                sman.LoadKeyFromStream(keyStream);
+                foreach (var key in SecureData.Keys)
+                {
+                    Assert.AreEqual(SecureData[key], sman.Get(key),
+                        $"Retrieved data for key \"{key}\" does not match stored value!");
+                }
+            }
+        }
+        
+        [TestMethod]
+        public async Task StoreAndLoadKeyFromStreamAsync()
+        {
+            var storePath = Path.GetTempFileName();
+            var keyPath = Path.GetTempFileName();
+
+            CreateTestStore(storePath, keyPath);
+
+            using (var storeStream = new FileStream(storePath, FileMode.Open, FileAccess.Read))
+            using (var keyStream = new FileStream(keyPath, FileMode.Open, FileAccess.Read))
+            using (var sman = SecretsManager.LoadStore(storeStream))
+            {
+                await sman.LoadKeyFromStreamAsync(keyStream);
+                foreach (var key in SecureData.Keys)
+                {
+                    Assert.AreEqual(SecureData[key], sman.Get(key),
+                        $"Retrieved data for key \"{key}\" does not match stored value!");
                 }
             }
         }


### PR DESCRIPTION
resolve issue #16 
- fixed stream position in LoadKeyFromStream, LoadKeyFromStreamAsync methods
- added unit tests